### PR TITLE
Introduce TileEntity GC (GarbageCollection) Flag

### DIFF
--- a/patches/net/minecraft/tileentity/TileEntity.java.patch
+++ b/patches/net/minecraft/tileentity/TileEntity.java.patch
@@ -15,6 +15,7 @@
 -    protected World worldObj;
 +    public static Map classToNameMap = new HashMap(); // Cauldron - private -> public
 +    public World worldObj; // CraftBukkit - protected -> public
++    private boolean GC = false;
      public int xCoord;
      public int yCoord;
      public int zCoord;
@@ -55,6 +56,17 @@
 +        return null;
 +    }
 +    // CraftBukkit end
++    //KCauldron start
++    public boolean isGC() //Returns true if the chunk it is inside of has marked it for unloading
++    {
++        return this.GC;
++    }
++
++    public boolean setGC(boolean state) //Should never be touched by a mod. Would make it package-private but not sure if that would still work
++    {
++        this.GC = state;
++    }
++    // KCauldron end
 +
      // -- BEGIN FORGE PATCHES --
      /**


### PR DESCRIPTION
TL; DR Lets server know if tile entity in an unloaded chunk is being processed.

Allowing a tile entity to be processed in an unloaded chunk introduces a whole host of problems. When a chunk's onChunkUnload() is called, it adds its tile entities to a list of tile entities to be unloaded by the World class. However, when a tile entity's onUnload() is called, it can try to access tile entities that have already been unloaded, making the server try to reload them when they shouldn't be.

When I get a chance I will actually add usage for this in the Chunk and World classes.

The implementation of this flag has been tested on a server of over 30 players for nearly a week now with no problems whatsoever. It has actually reduced lag significantly.