### PR TITLE
Start using GC Flag TileEntities

### DIFF
--- a/patches/net/minecraft/world/World.java.patch
+++ b/patches/net/minecraft/world/World.java.patch
@@ -923,9 +923,20 @@
 -            TileEntity tileentity = (TileEntity)iterator.next();
 +            for (Object tile : field_147483_b)
 +            {
-+                ((TileEntity) tile).onChunkUnload();
++                TileEntity te = (TileEntity)tile;
++                te.setGC(true);
++                te.onChunkUnload();
 +            }
-+            this.loadedTileEntityList.removeAll(this.field_147483_b);
++            List temporary_tile_entity_list = new ArrayList(this.loadedTileEntityList.size());
++            for(Object tile : loadedTileEntityList)
++                if(!((TileEntity)tile).isGC())
++                    temporary_tile_entity_list.add(tile);
++            this.loadedTileEntityList = temporary_tile_entity_list;
++            for (Object tile : field_147483_b)
++            {
++                TileEntity te = (TileEntity)tile;
++                te.setGC(false);
++            }
 +            this.field_147483_b.clear();
 +        }
 +        // CraftBukkit end


### PR DESCRIPTION
TL;DR Fixes problem where this.loadedTIleEntityList.removeAll() takes forever for large tile entity volumes.

I encountered this issue on my KCauldron server when using ZettaIndustries' BigBattery. When the battery is massive, it creates an unprecedented volume of tile entities than can cause removing unloaded TEs to hang and leave the server unresponsive. Does not happen for Procyon's official builds, but does happen on these Spanner builds. 

Now, utilizing the GC flag I implemented yesterday, the loadedTileEntityList will be pruned for TEs marked for removal (setGC()).

Just in case, the GC flag is reset after removal from the list. I do not know whether Forge re-uses already loaded Tiles, so this will prevent the possibility of TEs that should be loaded not being ticked.